### PR TITLE
Fix EEG monitor path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ This generates:
 Create video visualizations of EEG signals:
 
 ```bash
-cd '3. EEG Monitor (200 dpi, 30 fps for Fs=1000Hz)'
+cd '3. EEG Monitor (1600 dpi, 30 fps for Fs=1000Hz)'
 
 # For adaptive scaling
 python final.py
@@ -236,7 +236,7 @@ tFUS-EEG-ToolKit/
 │   ├── tFUS_EventAnalyzer_final.m   # Main temporal analysis
 │   ├── plotTemporalPSDmap.m         # Visualization function
 │   └── analysis/output/             # Results directory
-├── 3. EEG Monitor (200 dpi, 30 fps for Fs=1000Hz)/
+├── 3. EEG Monitor (1600 dpi, 30 fps for Fs=1000Hz)/
 │   ├── final.py                     # Adaptive scaling video
 │   └── final_fixed5000uv.py         # Fixed scaling video
 └── 4. Locomotion Analysis Tools/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating a directory name in usage examples and the project tree.
> 
> **Overview**
> Fixes the README’s EEG video-generation instructions and project structure tree to reference `3. EEG Monitor (1600 dpi, 30 fps for Fs=1000Hz)` instead of the outdated `200 dpi` directory name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3015d77e8dc5350776eb1468d2753fa490989b48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->