### PR TITLE
Add python smoke CI and glob support for Task 3

### DIFF
--- a/.github/workflows/python-smoke.yml
+++ b/.github/workflows/python-smoke.yml
@@ -1,0 +1,45 @@
+name: python-smoke
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+
+      - run: |
+          python -m py_compile \
+            "1. Tic Event Based Spectogram:EEG Analysis/eeg_spectrogram.py" \
+            "2. Peak Temporal Distrubution/temporal_peak_distribution.py" \
+            "3. EEG Monitor (1600 dpi, 30 fps for Fs=1000Hz)/final.py" \
+            "4. Locomotion Analysis Tools/locomotion_analysis.py" \
+            tool.py
+
+      - run: python "3. EEG Monitor (1600 dpi, 30 fps for Fs=1000Hz)/final.py" --help
+      - run: python "4. Locomotion Analysis Tools/locomotion_analysis.py" --help
+
+      - run: |
+          python "1. Tic Event Based Spectogram:EEG Analysis/eeg_spectrogram.py" \
+            "_EEG:EMG Dataset (STIM, SHAM 1ea each)/example_STIM_A.mat" \
+            --output-dir /tmp/eeg_py_smoke \
+            --save-detection-envelope
+
+      - run: |
+          python "2. Peak Temporal Distrubution/temporal_peak_distribution.py" \
+            --stim "_EEG:EMG Dataset (STIM, SHAM 1ea each)/example_STIM_A.mat" \
+            --sham "_EEG:EMG Dataset (STIM, SHAM 1ea each)/example_SHAM_A.mat" \
+            --output-dir /tmp/temporal_py_smoke
+
+      - run: test -f /tmp/temporal_py_smoke/temporal_peak_raw_data.csv
+      - run: test -f /tmp/temporal_py_smoke/temporal_peak_raw_data.xlsx

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ pip install -r requirements.txt
 
 ### Setup
 ```bash
-git clone https://github.com/myunghyunj/tFUS-EEG-ToolKit.git
-cd tFUS-EEG-ToolKit
+git clone https://github.com/myunghyunj/electrophysiology-ToolKit.git
+cd electrophysiology-ToolKit
 ```
 
 ## Usage
 
 ### Quick Start with Sample Data
 
-The repository includes two sample MAT files in the root directory:
+The repository includes two sample MAT files in `_EEG:EMG Dataset (STIM, SHAM 1ea each)/`:
 - `example_SHAM_A.mat` - Example sham condition data
 - `example_STIM_A.mat` - Example stimulation condition data
 
@@ -143,7 +143,7 @@ If you want one terminal entry point for all Python tools (tasks 1-4), run:
 python tool.py
 ```
 
-The launcher prompts for task number and accepts drag-dropped file or folder paths.
+The launcher prompts for a task number, accepts drag-dropped file or folder paths for tasks 1, 2, and 4, and supports either a single `.mat` file or a glob pattern for task 3.
 
 ### 5. Locomotion Analysis Tools
 
@@ -226,7 +226,7 @@ Notes:
 ## Project Structure
 
 ```
-tFUS-EEG-ToolKit/
+electrophysiology-ToolKit/
 ├── 0. rhd-mat converter (downsample)/
 │   ├── read_Intan_RHD2000_file.m    # Intan file reader
 │   └── rhd2plot_samplerate.m        # Main conversion script

--- a/tool.py
+++ b/tool.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import glob
 import shlex
 import subprocess
 import sys
@@ -47,17 +48,36 @@ def task_2() -> None:
 
 def task_3() -> None:
     mode = ask("Task 3 mode: [1] adaptive scale, [2] fixed ±5000 µV", "1")
-    raw = ask("Drop one .mat file for Task 3")
-    paths = parse_dragdrop_list(raw)
-    if len(paths) != 1:
-        raise SystemExit('Task 3 expects exactly one .mat file')
+    raw = ask("Drop one .mat file, or enter a glob pattern such as './*.mat'")
     output = ask("Output video file (leave blank for automatic naming)", "")
     window = ask("Visible window size in seconds", "6")
     fps = ask("Video FPS", "30")
     script = "final.py" if mode != "2" else "final_fixed5000uv.py"
-    args = [paths[0], "--window", window, "--fps", fps]
-    if output:
-        args += ["--output", output]
+
+    paths = parse_dragdrop_list(raw)
+    raw_target = raw.strip()
+    parsed_glob = len(paths) == 1 and glob.has_magic(paths[0])
+    raw_glob = glob.has_magic(raw_target)
+    raw_file = Path(raw_target)
+
+    if parsed_glob or raw_glob:
+        target = paths[0] if parsed_glob else raw_target
+        if output:
+            raise SystemExit("Custom output filename is only supported for single-file mode.")
+        args = ["--all", "--pattern", target, "--window", window, "--fps", fps]
+    else:
+        if raw_file.suffix.lower() == ".mat" and raw_file.exists():
+            target = raw_target
+        else:
+            if len(paths) != 1:
+                raise SystemExit('Task 3 expects exactly one .mat file or one glob pattern')
+            target = paths[0]
+        if Path(target).suffix.lower() != ".mat":
+            raise SystemExit("Task 3 expects a .mat file or a glob pattern matching .mat files.")
+        args = [target, "--window", window, "--fps", fps]
+        if output:
+            args += ["--output", output]
+
     run_script(REPO_ROOT / "3. EEG Monitor (1600 dpi, 30 fps for Fs=1000Hz)" / script, args)
 
 


### PR DESCRIPTION
Add a new GitHub Actions smoke workflow (.github/workflows/python-smoke.yml) that sets up Python 3.11, installs requirements, byte-compiles key scripts, runs help checks, executes sample runs, and asserts expected output files. Update README.md to reflect the repository rename to electrophysiology-ToolKit, adjust sample data path, clarify launcher behavior (tasks that accept drag-drop and Task 3 glob/single-file modes), and update project structure examples. Modify tool.py to import glob and rework task_3 to accept either a single .mat file or a glob pattern, support an --all/--pattern mode for batch processing, validate inputs and output filename usage, and improve error messages.