### PR TITLE
Harden Python release smoke checks and align version support

### DIFF
--- a/.github/workflows/python-smoke.yml
+++ b/.github/workflows/python-smoke.yml
@@ -7,13 +7,17 @@ on:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements.txt
@@ -43,3 +47,35 @@ jobs:
 
       - run: test -f /tmp/temporal_py_smoke/temporal_peak_raw_data.csv
       - run: test -f /tmp/temporal_py_smoke/temporal_peak_raw_data.xlsx
+
+      - run: |
+          python tests/generate_smoke_inputs.py \
+            --dlc-csv /tmp/locomotion_smoke/SHAM_synthetic.csv \
+            --eeg-mat /tmp/eeg_video_smoke/synthetic.mat
+
+      - run: |
+          python "4. Locomotion Analysis Tools/locomotion_analysis.py" \
+            preprocess /tmp/locomotion_smoke/SHAM_synthetic.csv \
+            --output-dir /tmp/locomotion_py_smoke
+
+      - run: |
+          python "4. Locomotion Analysis Tools/locomotion_analysis.py" \
+            analyze /tmp/locomotion_py_smoke \
+            --mm-per-pix 0.533 \
+            --bin-size-min 2.5 \
+            --output-dir /tmp/locomotion_py_smoke
+
+      - run: test -f /tmp/locomotion_py_smoke/SHAM_synthetic_head_tracking_3fps.csv
+      - run: test -f /tmp/locomotion_py_smoke/SHAM_synthetic_head_tracking_3fps.xlsx
+      - run: test -f /tmp/locomotion_py_smoke/binned_locomotion_2.5min.png
+      - run: test -f /tmp/locomotion_py_smoke/binned_locomotion_summary_2.5min.csv
+      - run: test -f /tmp/locomotion_py_smoke/binned_locomotion_summary_2.5min.xlsx
+
+      - run: |
+          python "3. EEG Monitor (1600 dpi, 30 fps for Fs=1000Hz)/final.py" \
+            /tmp/eeg_video_smoke/synthetic.mat \
+            --fps 5 \
+            --window 1 \
+            --output /tmp/eeg_video_smoke/synthetic.mp4
+
+      - run: test -f /tmp/eeg_video_smoke/synthetic.mp4

--- a/4. Locomotion Analysis Tools/locomotion_analysis.py
+++ b/4. Locomotion Analysis Tools/locomotion_analysis.py
@@ -323,6 +323,22 @@ def print_group_summary(animals: list[BinnedAnimal], group_name: str, bin_size_m
     print(f'  average distance per {bin_size_min:g}-min bin = {mean_bins.mean():.1f} ± {sample_sem(mean_bins):.1f} mm')
 
 
+
+
+def unique_tracking_files(files: list[Path]) -> list[Path]:
+    preferred: dict[str, Path] = {}
+    for file in sorted(files):
+        key = file.stem
+        if key.endswith('_head_tracking_3fps'):
+            key = key[:-len('_head_tracking_3fps')]
+        current = preferred.get(key)
+        if current is None:
+            preferred[key] = file
+            continue
+        if current.suffix.lower() != '.xlsx' and file.suffix.lower() == '.xlsx':
+            preferred[key] = file
+    return list(preferred.values())
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Python CLI for locomotion preprocessing and analysis')
     subparsers = parser.add_subparsers(dest='command', required=True)
@@ -349,6 +365,7 @@ def main() -> None:
             print(f'{result.basename}: total distance={result.total_distance_pixels:.2f} px, total time={result.total_time_sec:.2f} s, avg speed={result.avg_speed_pixels_per_sec:.2f} px/s, max speed={result.max_speed_pixels_per_sec:.2f} px/s')
         return
     files = discover_inputs(args.inputs, ('*_head_tracking_3fps.csv', '*_head_tracking_3fps.xlsx', '*.csv', '*.xlsx'))
+    files = unique_tracking_files(files)
     if not files:
         raise SystemExit('No tracking outputs found.')
     sham_files = [file for file in files if 'SHAM' in file.name.upper()]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Electrophysiology (EEG)-ToolKit
 
 [![MATLAB R2018b+](https://img.shields.io/badge/MATLAB-R2018b+-orange.svg)](https://www.mathworks.com/products/matlab.html)
-[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 ### This repository was used in this work [(IEEE TNSRE, 2025)](https://ieeexplore.ieee.org/abstract/document/11230828/)
@@ -34,6 +34,8 @@ This toolkit provides a complete pipeline for processing and analyzing EEG recor
 - Statistics and Machine Learning Toolbox *
 
 #### Python Requirements
+- Python 3.10 or later
+
 Install the Python dependencies with:
 ```bash
 pip install -r requirements.txt
@@ -102,7 +104,7 @@ Compare temporal patterns between STIM and SHAM conditions:
 
 ```matlab
 cd '2. Peak Temporal Distrubution'
-tFUS_EventAnalyzer_final
+tFUS_EventAnalyzer
 ```
 
 Python port:
@@ -234,7 +236,7 @@ electrophysiology-ToolKit/
 │   ├── eegSpectogram.m              # Main analysis script
 │   └── computeLogSpectrogram.m     # Helper function
 ├── 2. Peak Temporal Distrubution/
-│   ├── tFUS_EventAnalyzer_final.m   # Main temporal analysis
+│   ├── tFUS_EventAnalyzer.m   # Main temporal analysis
 │   ├── plotTemporalPSDmap.m         # Visualization function
 │   └── analysis/output/             # Results directory
 ├── 3. EEG Monitor (1600 dpi, 30 fps for Fs=1000Hz)/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 matplotlib
 scipy
-opencv-python
+opencv-python-headless
 h5py
 tqdm
 openpyxl

--- a/tests/generate_smoke_inputs.py
+++ b/tests/generate_smoke_inputs.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+import numpy as np
+from scipy.io import savemat
+
+
+def make_dlc_csv(path: Path, frames: int = 90) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    t = np.arange(frames, dtype=float)
+    x = 100.0 + 0.5 * t
+    y = 50.0 + 0.25 * t
+    likelihood = np.ones(frames, dtype=float) * 0.99
+    likelihood[10] = 0.5
+    likelihood[40] = 0.2
+
+    with path.open('w', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow(['scorer', 'DLC_resnet50', 'DLC_resnet50', 'DLC_resnet50'])
+        writer.writerow(['bodyparts', 'head', 'head', 'head'])
+        writer.writerow(['coords', 'x', 'y', 'likelihood'])
+        for idx in range(frames):
+            writer.writerow([int(idx), f'{x[idx]:.3f}', f'{y[idx]:.3f}', f'{likelihood[idx]:.3f}'])
+
+
+def make_eeg_mat(path: Path, samples: int = 2000, fs: int = 1000) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    t = np.arange(samples, dtype=float) / fs
+    signal = 800 * np.sin(2 * np.pi * 8 * t) + 100 * np.sin(2 * np.pi * 40 * t)
+    savemat(path, {'raw_data': signal.astype(np.float64)})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Generate tiny deterministic smoke-test inputs')
+    parser.add_argument('--dlc-csv', type=Path, required=True)
+    parser.add_argument('--eeg-mat', type=Path, required=True)
+    args = parser.parse_args()
+
+    make_dlc_csv(args.dlc_csv)
+    make_eeg_mat(args.eeg_mat)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Motivation
- Make the repository's stated Python support truthful and CI-aware because the codebase uses 3.10+ type syntax. 
- Ensure headless CI can import OpenCV and run lightweight smoke renders without installing system GL libraries. 
- Strengthen automated validation (especially component 4) with a deterministic end-to-end smoke test to catch regressions in preprocessing → analysis flows.

### Description
- Update documentation to state `Python 3.10+` and adjust the README Python badge and requirements text to match actual code usage. 
- Replace `opencv-python` with `opencv-python-headless` in `requirements.txt` to avoid `libGL.so.1` import failures in headless CI. 
- Expand the `python-smoke` workflow to a matrix on `3.10` and `3.13`, add deterministic smoke inputs and run end-to-end checks for locomotion preprocessing/analyze and a tiny EEG render producing an MP4. 
- Add `tests/generate_smoke_inputs.py` to produce a small deterministic DLC CSV and a tiny `.mat` EEG file for CI smoke tests. 
- Fix a real locomotion-analysis bug by de-duplicating tracking outputs in `4. Locomotion Analysis Tools/locomotion_analysis.py` with a `unique_tracking_files` helper that prefers `.xlsx` over `.csv` for the same animal basename.

### Testing
- Baseline failure observed before changes: `python "3. EEG Monitor .../final.py" --help` failed with `ImportError: libGL.so.1: cannot open shared object file`, which motivated switching to the headless OpenCV wheel. 
- Environment install: `python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt` completed successfully after the dependency change. 
- Static/quick checks: `python -m py_compile` for `eeg_spectrogram.py`, `temporal_peak_distribution.py`, `final.py`, `locomotion_analysis.py`, and `tool.py` succeeded. 
- Component help checks: `final.py --help` and `locomotion_analysis.py --help` succeeded after the fix. 
- Component runs: `eeg_spectrogram.py` on the included `example_STIM_A.mat` and `temporal_peak_distribution.py` (STIM/SHAM pair) completed and produced expected outputs including `temporal_peak_raw_data.csv` and `temporal_peak_raw_data.xlsx`. 
- New smoke flows: `tests/generate_smoke_inputs.py` produced deterministic DLC CSV and tiny MAT; `locomotion_analysis.py preprocess` + `analyze` completed and produced `_head_tracking_3fps.csv`, `_head_tracking_3fps.xlsx`, `binned_locomotion_2.5min.png`, and summary CSV/XLSX; the tiny `final.py` render produced `/tmp/.../synthetic.mp4`; all CI file-existence assertions passed locally. 
- Result: all added automated smoke checks succeeded locally and the repo now declares a truthful Python minimum and avoids headless OpenCV import failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0b340ada88326b6794b2ad2d9097f)