### PR TITLE
Harden Python release validation and locomotion smoke tests

### DIFF
--- a/.github/workflows/python-smoke.yml
+++ b/.github/workflows/python-smoke.yml
@@ -7,13 +7,16 @@ on:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements.txt
@@ -43,3 +46,14 @@ jobs:
 
       - run: test -f /tmp/temporal_py_smoke/temporal_peak_raw_data.csv
       - run: test -f /tmp/temporal_py_smoke/temporal_peak_raw_data.xlsx
+
+      - run: |
+          python tests/generate_synthetic_dlc_csv.py
+          python "4. Locomotion Analysis Tools/locomotion_analysis.py" preprocess /tmp/locomotion_synthetic --output-dir /tmp/locomotion_py_smoke
+          python "4. Locomotion Analysis Tools/locomotion_analysis.py" analyze /tmp/locomotion_py_smoke --mm-per-pix 0.533 --bin-size-min 2.5 --output-dir /tmp/locomotion_py_smoke
+
+      - run: test -f /tmp/locomotion_py_smoke/mouse_SHAM_head_head_tracking_3fps.csv
+      - run: test -f /tmp/locomotion_py_smoke/mouse_STIM_head_head_tracking_3fps.xlsx
+      - run: test -f /tmp/locomotion_py_smoke/mouse_SHAM_head_head_analysis_3fps.png
+      - run: test -f /tmp/locomotion_py_smoke/binned_locomotion_2.5min.png
+      - run: test -f /tmp/locomotion_py_smoke/binned_locomotion_summary_2.5min.csv

--- a/3. EEG Monitor (1600 dpi, 30 fps for Fs=1000Hz)/final.py
+++ b/3. EEG Monitor (1600 dpi, 30 fps for Fs=1000Hz)/final.py
@@ -3,7 +3,6 @@ import matplotlib.pyplot as plt
 import matplotlib
 from scipy import io
 from scipy.signal import butter, filtfilt
-import cv2
 import os
 from tqdm import tqdm
 import glob
@@ -13,7 +12,18 @@ import h5py
 matplotlib.use('agg')  # Non-interactive backend, better for video generation
 plt.rcParams['figure.dpi'] = 1600
 
+def _require_cv2():
+    try:
+        import cv2  # type: ignore
+    except Exception as exc:
+        raise RuntimeError(
+            "OpenCV (cv2) is required for video rendering. Install opencv-python and system GL runtime (e.g., libGL)."
+        ) from exc
+    return cv2
+
+
 def create_eeg_video(mat_file, out_file='eeg_video.mp4', window_size=6, fps=30):
+    cv2 = _require_cv2()
     print(f"Loading data from {mat_file}...")
     
     # Try to determine if file is v7.3 format

--- a/3. EEG Monitor (1600 dpi, 30 fps for Fs=1000Hz)/final_fixed5000uv.py
+++ b/3. EEG Monitor (1600 dpi, 30 fps for Fs=1000Hz)/final_fixed5000uv.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 import matplotlib
 from scipy import io
 from scipy.signal import butter, filtfilt
-import cv2
 import os
 from tqdm import tqdm
 import glob
@@ -60,7 +59,18 @@ def calculate_scale_positions(signal_min, signal_max, target_bottom, target_top,
     
     return np.array(scale_positions), np.array(scale_values)
 
+def _require_cv2():
+    try:
+        import cv2  # type: ignore
+    except Exception as exc:
+        raise RuntimeError(
+            "OpenCV (cv2) is required for video rendering. Install opencv-python and system GL runtime (e.g., libGL)."
+        ) from exc
+    return cv2
+
+
 def create_eeg_video(mat_file, out_file='eeg_video.mp4', window_size=6, fps=30, adaptive_scale=True):
+    cv2 = _require_cv2()
     print(f"Loading data from {mat_file}...")
     
     # Try to determine if file is v7.3 format

--- a/4. Locomotion Analysis Tools/locomotion_analysis.py
+++ b/4. Locomotion Analysis Tools/locomotion_analysis.py
@@ -206,6 +206,20 @@ def read_tracking_table(file: Path) -> list[dict[str, float]]:
     raise ValueError(f'Unsupported tracking table or missing openpyxl support: {file}')
 
 
+
+
+def unique_tracking_files(files: list[Path]) -> list[Path]:
+    preferred: dict[str, Path] = {}
+    for file in files:
+        key = file.stem
+        existing = preferred.get(key)
+        if existing is None:
+            preferred[key] = file
+            continue
+        if existing.suffix.lower() == '.csv' and file.suffix.lower() in {'.xlsx', '.xls'}:
+            preferred[key] = file
+    return list(preferred.values())
+
 def build_binned_animals(files: list[Path], bin_size_min: float, mm_per_pix: float) -> tuple[list[BinnedAnimal], int]:
     animals: list[BinnedAnimal] = []
     max_bins = 0
@@ -349,6 +363,7 @@ def main() -> None:
             print(f'{result.basename}: total distance={result.total_distance_pixels:.2f} px, total time={result.total_time_sec:.2f} s, avg speed={result.avg_speed_pixels_per_sec:.2f} px/s, max speed={result.max_speed_pixels_per_sec:.2f} px/s')
         return
     files = discover_inputs(args.inputs, ('*_head_tracking_3fps.csv', '*_head_tracking_3fps.xlsx', '*.csv', '*.xlsx'))
+    files = unique_tracking_files(files)
     if not files:
         raise SystemExit('No tracking outputs found.')
     sham_files = [file for file in files if 'SHAM' in file.name.upper()]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Electrophysiology (EEG)-ToolKit
 
 [![MATLAB R2018b+](https://img.shields.io/badge/MATLAB-R2018b+-orange.svg)](https://www.mathworks.com/products/matlab.html)
-[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 ### This repository was used in this work [(IEEE TNSRE, 2025)](https://ieeexplore.ieee.org/abstract/document/11230828/)
@@ -34,6 +34,8 @@ This toolkit provides a complete pipeline for processing and analyzing EEG recor
 - Statistics and Machine Learning Toolbox *
 
 #### Python Requirements
+- Python 3.11 or newer
+
 Install the Python dependencies with:
 ```bash
 pip install -r requirements.txt
@@ -133,6 +135,14 @@ python final.py
 
 # For fixed ±5000 µV scaling
 python final_fixed5000uv.py
+```
+
+Local smoke test for video renderer (small/fast run):
+
+```bash
+python '3. EEG Monitor (1600 dpi, 30 fps for Fs=1000Hz)/final.py' \
+  '_EEG:EMG Dataset (STIM, SHAM 1ea each)/example_STIM_A.mat' \
+  --window 1 --fps 2 --output /tmp/eeg_video_smoke.mp4
 ```
 
 ### 4.5 Unified Python CLI launcher

--- a/tests/generate_synthetic_dlc_csv.py
+++ b/tests/generate_synthetic_dlc_csv.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+
+def write_dlc_csv(path: Path, x_start: float, y_start: float, dx: float, dy: float, frames: int = 120) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["scorer", "synthetic_model", "synthetic_model", "synthetic_model"])
+        writer.writerow(["bodyparts", "head", "head", "head"])
+        writer.writerow(["coords", "x", "y", "likelihood"])
+        for frame in range(frames):
+            x = x_start + dx * frame
+            y = y_start + dy * frame
+            likelihood = 0.97 if frame % 11 else 0.85
+            writer.writerow([frame, f"{x:.3f}", f"{y:.3f}", f"{likelihood:.3f}"])
+
+
+def main() -> None:
+    out_dir = Path("/tmp/locomotion_synthetic")
+    write_dlc_csv(out_dir / "mouse_SHAM_head.csv", x_start=100.0, y_start=50.0, dx=0.75, dy=0.20)
+    write_dlc_csv(out_dir / "mouse_STIM_head.csv", x_start=95.0, y_start=60.0, dx=0.60, dy=0.35)
+    print(out_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Ensure Python entry points are reliable in CI and local smoke runs and make the repo's stated Python support truthful.  
- Allow CLI help and lightweight checks to work in headless CI where system OpenCV/GL runtime may be missing.  
- Add real end-to-end validation for the locomotion pipeline so CI exercises both `preprocess` and `analyze`.  
- Fix a discovered duplicate-counting issue where CSV and XLSX tracking outputs for the same animal were treated as separate animals.

### Description
- Deferred the top-level `cv2` import and added a helper `_require_cv2()` that imports `cv2` at video-render time and raises a clear error if the system GL/runtime is missing, preserving `--help` and non-video CLI usage; applied to both `final.py` and `final_fixed5000uv.py`.  
- Updated Python support to `3.11+` (README badge/text) and adjusted the GitHub Actions smoke workflow to run a Python matrix testing `3.11` and `3.12`.  
- Added a deterministic synthetic DLC CSV generator (`tests/generate_synthetic_dlc_csv.py`) and extended `.github/workflows/python-smoke.yml` to run a small end-to-end locomotion smoke path that runs `preprocess` and `analyze` and asserts expected CSV/XLSX/PNG outputs.  
- Implemented `unique_tracking_files()` in `4. Locomotion Analysis Tools/locomotion_analysis.py` and deduped discoverd files (prefer `.xlsx` over `.csv` for identical stems) before grouping to avoid double-counting animals; integrated this into the `analyze` flow.  
- Updated README with the adjusted Python requirement and a documented lightweight local smoke command for component 3 video rendering (kept out of CI due to environment GL dependency).

### Testing
- Ran `python -m py_compile` on the entry points and verified compilation succeeded for `eeg_spectrogram.py`, `temporal_peak_distribution.py`, `final.py`, `locomotion_analysis.py`, and `tool.py`.  
- Verified CLI help works: `python "3. EEG Monitor .../final.py" --help` and `python "4. Locomotion Analysis Tools/locomotion_analysis.py" --help` both succeeded after the deferred `cv2` import fix.  
- Executed the sample-data smoke runs: `eeg_spectrogram.py` and `temporal_peak_distribution.py` completed successfully and produced `/tmp/temporal_py_smoke/temporal_peak_raw_data.csv` and `.xlsx`.  
- Exercised the new locomotion smoke path by running `tests/generate_synthetic_dlc_csv.py`, then `locomotion_analysis.py preprocess` and `locomotion_analysis.py analyze` and asserted the expected outputs (`*_head_tracking_3fps.csv/.xlsx`, `_head_analysis_3fps.png`, `binned_locomotion_2.5min.png`, and `binned_locomotion_summary_2.5min.csv`) — all passed; note that full component-3 video rendering still fails in CI hosts that lack `libGL.so.1` and is documented as a local smoke path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0b340ada88326b6794b2ad2d9097f)